### PR TITLE
fix: add localization to directory manager config

### DIFF
--- a/default/resources/pages/directory-manager/defaultDirectory.json
+++ b/default/resources/pages/directory-manager/defaultDirectory.json
@@ -7,6 +7,9 @@
       "location"
     ]
   },
+  "localization": {
+    "locales": ["en"]
+  },
   "root": {
     "entityType": "ce_root",
     "slug": "index.html",


### PR DESCRIPTION
localization was recently made a required field

TEST=none