### PR TITLE
feat: disable autodeploy by default

### DIFF
--- a/default/resources/pages/yextsite-config/site.json
+++ b/default/resources/pages/yextsite-config/site.json
@@ -4,7 +4,7 @@
   "siteName": "Site",
   "repoConfig": "starter-repo",
   "siteSettings": {
-    "autoDeploy": true,
+    "autoDeploy": false,
     "autoStage": true,
     "autoPublish": false,
     "pullRequestsEnabled": false,


### PR DESCRIPTION
this change is at the request of product. publishing the starter site creates streams for DM entities before they exist. when the DM runs it causes a spike as each entity is created. we should be able to revert at some point when product has finished re-architecting the DM

J/T=none

TEST=none